### PR TITLE
Add support to laz-perf

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,22 +14,30 @@ RUN apt-get update \
         git \
         ca-certificates \
         build-essential \
+        cmake \
         autoconf \
         automake \
         zlib1g-dev \
         postgresql-server-dev-all \
         libxml2-dev \
     && rm -rf /var/lib/apt/lists/* \
+    && git clone https://github.com/verma/laz-perf.git \
+    && cd laz-perf \
+    && cmake . \
+    && make \
+    && make install \
+    && cd / \
     && git clone https://github.com/pgpointcloud/pointcloud \
     && cd pointcloud \
     && ./autogen.sh \
-    && ./configure --with-pgconfig=/usr/lib/postgresql/${POSTGRES_VERSION}/bin/pg_config CFLAGS="-Wall -Werror -O2 -g" \
+    && ./configure --with-pgconfig=/usr/lib/postgresql/${POSTGRES_VERSION}/bin/pg_config CFLAGS="-Wall -Werror -O2 -g" --with-lazperf=/usr/local \
     && make \
     && make install \
     && apt-get purge -y --auto-remove \
         git \
         ca-certificates \
         build-essential \
+        cmake \
         autoconf \
         automake \
         zlib1g-dev \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update \
         autoconf \
         automake \
         zlib1g-dev \
-        postgresql-server-dev-all \
+        postgresql-server-dev-${POSTGRES_VERSION} \
         libxml2-dev \
     && rm -rf /var/lib/apt/lists/* \
     && git clone https://github.com/verma/laz-perf.git \
@@ -30,7 +30,7 @@ RUN apt-get update \
     && git clone https://github.com/pgpointcloud/pointcloud \
     && cd pointcloud \
     && ./autogen.sh \
-    && ./configure --with-pgconfig=/usr/lib/postgresql/${POSTGRES_VERSION}/bin/pg_config CFLAGS="-Wall -Werror -O2 -g" --with-lazperf=/usr/local \
+    && ./configure CFLAGS="-Wall -Werror -O2 -g" --with-lazperf=/usr/local \
     && make \
     && make install \
     && apt-get purge -y --auto-remove \
@@ -41,5 +41,5 @@ RUN apt-get update \
         autoconf \
         automake \
         zlib1g-dev \
-        postgresql-server-dev-all \
+        postgresql-server-dev-${POSTGRES_VERSION}  \
         libxml2-dev


### PR DESCRIPTION
From the `docker build` output.
```
  PointCloud is now configured for

 -------------- Compiler Info -------------
  C compiler:           gcc -Wall -Werror -O2 -g
  SQL preprocessor:     /usr/bin/cpp -traditional-cpp -w -P

 -------------- Dependencies --------------
  PostgreSQL config:    /usr/lib/postgresql/9.6/bin/pg_config
  PostgreSQL version:   PostgreSQL 9.6.11 (96)
  Libxml2 config:       /usr/bin/xml2-config
  Libxml2 version:      2.9.4
  LazPerf status:       /usr/local/include/laz-perf
  CUnit status:         disabled
```


I also made sure only the specified version of postgres is installed. It is useful to fix problems when building Oslandia/pgmorton as well.